### PR TITLE
Expose form fields to the user

### DIFF
--- a/app/handlers/Exec.py
+++ b/app/handlers/Exec.py
@@ -60,9 +60,19 @@ class ExecHandler(SentryMixin, RequestHandler):
             },
         }
 
+        # TODO: deprecate query_params once OMS supports deprecation
+        # https://github.com/microservices/openmicroservices.org/pull/142
         event['data']['query_params'] = {}
         for k, v in self.request.arguments.items():
             event['data']['query_params'][k] = v[0].decode('utf-8')
+
+        event['data']['queryParams'] = {}
+        for k, v in self.request.query_arguments.items():
+            event['data']['queryParams'][k] = v[0].decode('utf-8')
+
+        event['data']['formFields'] = {}
+        for k, v in self.request.body_arguments.items():
+            event['data']['formFields'][k] = v[0].decode('utf-8')
 
         if 'application/json' in self.request.headers.get('content-type', ''):
             event['data']['body'] = json.loads(

--- a/microservice.yml
+++ b/microservice.yml
@@ -84,14 +84,36 @@ actions:
               help: The HTTP headers of the incoming HTTP request
               type: map
             query_params:
+              help: |
+                DEPRECATED. Use 'queryParams'.
+              type: map
+              map:
+                keys:
+                  type: string
+                values:
+                  type: string
+            queryParams:
               help: The parsed query parameters of the HTTP request
               type: map
+              map:
+                keys:
+                  type: string
+                values:
+                  type: string
             uri:
               help: The URI of the incoming HTTP request
               type: string
             path:
               help: The path portion of the URI of the incoming HTTP request
               type: string
+            formFields:
+              help: The form fields of the incoming HTTP request
+              type: map
+              map:
+                keys:
+                  type: string
+                values:
+                  type: string
             files:
               type: map
               map:


### PR DESCRIPTION
`query_params` can be marked as deprecated as soon as https://github.com/microservices/openmicroservices.org/pull/142 is official and part of OMS.